### PR TITLE
Fix: tasks list endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -231,7 +231,7 @@ server.tool(
         );
       } else {
         // Get all tasks
-        response = await client.get<Task[]>("/tasks/all", query);
+        response = await client.get<Task[]>("/tasks", query);
       }
 
       return formatResponse({ tasks: response.data, pagination: response.pagination });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -283,7 +283,7 @@ describe("MCP Tool Handlers", () => {
       const response = await callTool("tasks_list", {});
       const data = parseResponse(response);
 
-      expect(mockGet).toHaveBeenCalledWith("/tasks/all", expect.any(Object));
+      expect(mockGet).toHaveBeenCalledWith("/tasks", expect.any(Object));
       expect(data.tasks).toEqual(mockTasks);
     });
 
@@ -336,7 +336,7 @@ describe("MCP Tool Handlers", () => {
         filter: "done = false",
       });
 
-      expect(mockGet).toHaveBeenCalledWith("/tasks/all", {
+      expect(mockGet).toHaveBeenCalledWith("/tasks", {
         page: 2,
         per_page: 25,
         s: "bug",


### PR DESCRIPTION
I was getting errors of "invalid model provided" on the `tasks_list` endpoint - bit of quick research unveiled that they changed the API in January in their 1.0 release:

https://vikunja.io/changelog/whats-new-in-vikunja-1.0.0/#api-route-changes

so `tasks/all` should now be `tasks`.